### PR TITLE
chore(pkg): Upgrade `advanced` and `webpack` devDependencies

### DIFF
--- a/templates/advanced/$package.json
+++ b/templates/advanced/$package.json
@@ -18,7 +18,7 @@
     "css-loader": "^0.28.7",
     "extract-text-webpack-plugin": "^3.0.0",
     "html-loader": "^0.4.5",
-    "html-webpack-plugin": "^2.28.0",
+    "html-webpack-plugin": "^3.2.0",
     "node-sass": "^4.5.3",
     "sass-loader": "^6.0.6",
     "source-map-loader": "^0.2.1",

--- a/templates/advanced/$package.json
+++ b/templates/advanced/$package.json
@@ -16,7 +16,6 @@
     "browser-sync": "^2.18.13",
     "browser-sync-webpack-plugin": "^1.2.0",
     "css-loader": "^0.28.7",
-    "extract-text-webpack-plugin": "^3.0.0",
     "html-loader": "^0.4.5",
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.5.0",

--- a/templates/advanced/$package.json
+++ b/templates/advanced/$package.json
@@ -19,6 +19,7 @@
     "extract-text-webpack-plugin": "^3.0.0",
     "html-loader": "^0.4.5",
     "html-webpack-plugin": "^3.2.0",
+    "mini-css-extract-plugin": "^0.5.0",
     "node-sass": "^4.5.3",
     "sass-loader": "^6.0.6",
     "source-map-loader": "^0.2.1",

--- a/templates/advanced/$package.json
+++ b/templates/advanced/$package.json
@@ -25,7 +25,7 @@
     "style-loader": "^0.18.2",
     "to-string-loader": "^1.1.5",
     "webpack": "^3.6.0",
-    "webpack-dev-server": "^2.5.0"
+    "webpack-dev-server": "^3.1.14"
   },
   "dependencies": {
     "@storefront/breadcrumbs": "latest",

--- a/templates/advanced/$package.json
+++ b/templates/advanced/$package.json
@@ -24,7 +24,8 @@
     "source-map-loader": "^0.2.1",
     "style-loader": "^0.18.2",
     "to-string-loader": "^1.1.5",
-    "webpack": "^3.6.0",
+    "webpack": "^4.29.0",
+    "webpack-cli": "^3.2.1",
     "webpack-dev-server": "^3.1.14"
   },
   "dependencies": {

--- a/templates/advanced/webpack.config.js
+++ b/templates/advanced/webpack.config.js
@@ -1,4 +1,4 @@
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 const HTMLPlugin = require('html-webpack-plugin');
 const path = require('path');
@@ -17,7 +17,7 @@ module.exports = {
 
   plugins: [
     new HTMLPlugin({ template: indexHtml }),
-    new ExtractTextPlugin('styles.css'),
+    new MiniCssExtractPlugin({ filename: 'styles.css' }),
     new BrowserSyncPlugin({
         host: 'localhost',
         port: 6400,
@@ -55,13 +55,11 @@ module.exports = {
       ]
     }, {
       test: /\.scss$/,
-      use: ExtractTextPlugin.extract({
-        use: [
-          'css-loader',
-          'sass-loader'
-        ],
-        fallback: 'style-loader'
-      })
+      use: [
+        MiniCssExtractPlugin.loader,
+        'css-loader',
+        'sass-loader'
+      ]
     }]
   },
 

--- a/templates/webpack/$package.json
+++ b/templates/webpack/$package.json
@@ -15,9 +15,9 @@
     "browser-sync": "^2.18.13",
     "browser-sync-webpack-plugin": "^1.2.0",
     "css-loader": "^0.28.4",
-    "file-loader": "^0.11.2",
+    "file-loader": "^3.0.1",
     "html-loader": "^0.4.5",
-    "html-webpack-plugin": "^2.28.0",
+    "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.5.0",
     "node-sass": "^4.5.3",
     "sass-loader": "^6.0.6",
@@ -25,7 +25,6 @@
     "style-loader": "^0.18.2",
     "webpack": "^4.29.0",
     "webpack-cli": "^3.2.1",
-    "webpack-dev-server": "^3.1.14",
-    "webpack-html-plugin": "^0.1.1"
+    "webpack-dev-server": "^3.1.14"
   }
 }

--- a/templates/webpack/$package.json
+++ b/templates/webpack/$package.json
@@ -15,15 +15,17 @@
     "browser-sync": "^2.18.13",
     "browser-sync-webpack-plugin": "^1.2.0",
     "css-loader": "^0.28.4",
-    "extract-text-webpack-plugin": "^2.1.2",
     "file-loader": "^0.11.2",
     "html-loader": "^0.4.5",
     "html-webpack-plugin": "^2.28.0",
+    "mini-css-extract-plugin": "^0.5.0",
     "node-sass": "^4.5.3",
     "sass-loader": "^6.0.6",
     "source-map-loader": "^0.2.1",
     "style-loader": "^0.18.2",
-    "webpack": "^2.5.0",
-    "webpack-dev-server": "^2.5.0"
+    "webpack": "^4.29.0",
+    "webpack-cli": "^3.2.1",
+    "webpack-dev-server": "^3.1.14",
+    "webpack-html-plugin": "^0.1.1"
   }
 }

--- a/templates/webpack/webpack.config.js
+++ b/templates/webpack/webpack.config.js
@@ -1,4 +1,4 @@
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 const HTMLPlugin = require('html-webpack-plugin');
 const path = require('path');
@@ -17,7 +17,7 @@ module.exports = {
 
   plugins: [
     new HTMLPlugin({ template: indexHtml }),
-    new ExtractTextPlugin('styles.css'),
+    new MiniCssExtractPlugin({ filename: 'styles.css' }),
     new BrowserSyncPlugin({
         host: 'localhost',
         port: 6400,
@@ -44,13 +44,11 @@ module.exports = {
       options: { interpolate: true }
     }, {
       test: /\.scss$/,
-      use: ExtractTextPlugin.extract({
-        use: [
-          'css-loader',
-          'sass-loader'
-        ],
-        fallback: 'style-loader'
-      })
+      use: [
+        MiniCssExtractPlugin.loader,
+        'css-loader',
+        'sass-loader'
+      ]
     }]
   },
 


### PR DESCRIPTION
The PR introduces the following changes for to the `advanced` and `webpack` starter projects:
- Upgrade `webpack` to `v4.X.X`.
- Upgrade related dependencies to `webpack@4` compliant versions.
- Replace `ExtractTextPlugin` with `MiniCssExtractPlugin` (as per: https://github.com/webpack-contrib/extract-text-webpack-plugin).